### PR TITLE
Adding an aria-label to the button

### DIFF
--- a/templates/field--field-gallery-images.tpl.php
+++ b/templates/field--field-gallery-images.tpl.php
@@ -9,8 +9,8 @@ $nid = $element['#object']->nid;
   <?php
   $image_target = $nid . '-' . $delta;
   ?>
-  <?php if (isset($item['#item']['uri'])): ?>
-        <button type="button" class="toggle-button" data-toggle="modal"
+  <?php if (isset($item['#item']['uri']) && isset($item['#item']['alt'])): ?>
+        <button aria-label="<?php print t('Open @alt', ['@alt' => $item['#item']['alt']]); ?>" type="button" class="toggle-button" data-toggle="modal"
                 data-target="#<?php print $image_target; ?>">
           <?php
           try {


### PR DESCRIPTION
Add's an aria-label to each button, "Open `alt text`". The label text is `t()` wrapped so we can translate `Open @alt`.

It also adds a check to ensure the image has alt text before attempting to print it. This will hide images without `alt` text from displaying.

See https://github.com/CityofOttawa/ottawa_profile/issues/3009 for more information.